### PR TITLE
Convert Graph & subclasses to use smart pointers

### DIFF
--- a/src/graph/Edge.cpp
+++ b/src/graph/Edge.cpp
@@ -1,7 +1,7 @@
 #include "Edge.h"
 #include "Vertex.h"
 
-Edge::Edge(Vertex* v1, Vertex* v2, bool belongs) {
+Edge::Edge(shared_ptr<Vertex> v1, shared_ptr<Vertex> v2, bool belongs) {
     // keep the vertices lexographically ordered
     if (*v1 < *v2) {
         this->a = v1;
@@ -40,10 +40,10 @@ ostream& operator<<(ostream& out, const Edge& rhs) {
     return out;
 }
 
-Vertex* Edge::getFirst() const {
+shared_ptr<Vertex> Edge::getFirst() const {
     return a;
 }
 
-Vertex* Edge::getSecond() const {
+shared_ptr<Vertex> Edge::getSecond() const {
     return b;
 }

--- a/src/graph/Edge.h
+++ b/src/graph/Edge.h
@@ -1,5 +1,6 @@
 #include "Vertex.h"
 #include <iostream>
+#include <memory>
 
 using namespace std;
 
@@ -8,17 +9,17 @@ using namespace std;
 
 class Edge {
     private:
-        Vertex* a;
-        Vertex* b;
+        shared_ptr<Vertex> a;
+        shared_ptr<Vertex> b;
         bool belongs;
     public:
-        Edge(Vertex*, Vertex*, bool belongs = true);
+        Edge(shared_ptr<Vertex>, shared_ptr<Vertex>, bool belongs = true);
         ~Edge();
         friend bool operator==(const Edge& lhs, const Edge& rhs);
         friend bool operator<(const Edge&, const Edge&);
         friend ostream& operator<<(ostream&, const Edge&);
-        Vertex* getFirst() const;
-        Vertex* getSecond() const;
+        shared_ptr<Vertex> getFirst() const;
+        shared_ptr<Vertex> getSecond() const;
 };
 
 #endif          // EDGE_H__

--- a/src/graph/Graph.h
+++ b/src/graph/Graph.h
@@ -11,15 +11,15 @@ using namespace std;
 
 class Graph {
     private:
-        set<Edge*>* edges;
-        set<Vertex*>* vertices;
+        set<shared_ptr<Edge>>* edges;
+        set<shared_ptr<Vertex>>* vertices;
     public:
         Graph();
         ~Graph();
         bool import(string filename);
-        bool join(Vertex*, Vertex*, bool = true);
-        bool separate(Vertex*, Vertex*);
-        // TODO: operator overload for copy, ostream
+        bool join(shared_ptr<Vertex>, shared_ptr<Vertex>, bool = true);
+        bool separate(shared_ptr<Vertex>, shared_ptr<Vertex>);
+        // TODO: operator overload for ostream
 };
 
 #endif          // GRAPH_H__

--- a/test/graph/test_edge.cpp
+++ b/test/graph/test_edge.cpp
@@ -1,5 +1,6 @@
 #include "Edge.h"
 #include "Vertex.h"
+#include <memory>
 #include <cassert>
 
 using namespace std;
@@ -17,23 +18,21 @@ int main() {
 }
 
 bool testCreation() {
-    Vertex* v1 = new Vertex("a");
-    Vertex* v2 = new Vertex("b");
+    shared_ptr<Vertex> v1 = make_shared<Vertex>("a");
+    shared_ptr<Vertex> v2 = make_shared<Vertex>("b");
     Edge* e1 = new Edge(v1, v2, false);
     assert(*(e1->getFirst()) == *v1);
     assert(*(e1->getSecond()) == *v2);
     delete e1;
-    delete v1;
-    delete v2;
     return true;
 }
 
 bool testEquality() {
-    Vertex* v1 = new Vertex("a");
-    Vertex* v2 = new Vertex("b");
-    Vertex* v3 = new Vertex("c");
+    shared_ptr<Vertex> v1 = make_shared<Vertex>("a");
+    shared_ptr<Vertex> v2 = make_shared<Vertex>("b");
+    shared_ptr<Vertex> v3 = make_shared<Vertex>("c");
     // different obj/ptr, same name
-    Vertex* v4 = new Vertex("b");
+    shared_ptr<Vertex> v4 = make_shared<Vertex>("b");
     Edge* ex1f = new Edge(v1, v2, false);
     Edge* ex1b = new Edge(v2, v1, false);
     Edge* ex2f = new Edge(v1, v3, false);
@@ -45,10 +44,6 @@ bool testEquality() {
     assert(*ex2f == *ex2b);
     assert(!(*ex1f == *ex2f));
     assert(*ex1f == *ex1repeat);
-    delete v1;
-    delete v2;
-    delete v3;
-    delete v4;
     delete ex1f;
     delete ex1b;
     delete ex2f;
@@ -59,10 +54,11 @@ bool testEquality() {
 
 bool testLessThanOperator() {
     // create vertices
-    Vertex* v1 = new Vertex("a");
-    Vertex* v2 = new Vertex("b");
-    Vertex* v3 = new Vertex("c");
-    Vertex* v4 = new Vertex("b");                       // different obj/ptr, same name
+    shared_ptr<Vertex> v1 = make_shared<Vertex>("a");
+    shared_ptr<Vertex> v2 = make_shared<Vertex>("b");
+    shared_ptr<Vertex> v3 = make_shared<Vertex>("c");
+    // different obj/ptr, same name
+    shared_ptr<Vertex> v4 = make_shared<Vertex>("b");
     // create edges
     Edge* e1 = new Edge(v1, v1, false);     // (a, a)
     Edge* e2 = new Edge(v2, v1, false);     // (a, b)
@@ -73,10 +69,6 @@ bool testLessThanOperator() {
     assert(*e2 < *e3);
     assert(*e1 < *e4);
     assert(!(*e1 < *e1));
-    delete v1;
-    delete v2;
-    delete v3;
-    delete v4;
     delete e1;
     delete e2;
     delete e3;

--- a/test/graph/test_graph.cpp
+++ b/test/graph/test_graph.cpp
@@ -30,9 +30,9 @@ bool createNonEmptyGraphFromFile() {
 
 bool createNonEmptyGraphFromBoutiqueVertices() {
     Graph g;
-    Vertex* v1 = new Vertex("a");
-    Vertex* v2 = new Vertex("b");
-    Vertex* v3 = new Vertex("c");
+    shared_ptr<Vertex> v1 = make_shared<Vertex>("a");
+    shared_ptr<Vertex> v2 = make_shared<Vertex>("b");
+    shared_ptr<Vertex> v3 = make_shared<Vertex>("c");
     cout << "Join v1 and v2 (a, b)..." << endl;
     assert(g.join(v1, v2));
     cout << "Sep v2 and v3 (b, c) (should fail)" << endl;


### PR DESCRIPTION
This should help simplify overlapping use of Vertex & Edge objects without introducing memory leaks. Test conversion has already eliminated existing leaks, and all tests continue to pass.