### PR TITLE
Add operator overloads to Graph & Vertex classes

### DIFF
--- a/src/graph/Graph.cpp
+++ b/src/graph/Graph.cpp
@@ -3,6 +3,7 @@
 #include <set>
 #include <fstream>  // std::ifstream
 #include <memory>   // std::shared_ptr, std::make_shared
+#include <iostream>
 #include "Graph.h"
 #include "Vertex.h"
 #include "Edge.h"
@@ -172,4 +173,20 @@ Graph& Graph::operator=(const Graph& rhs) {
 pair<Graph*, Graph*>* Graph::splitTree(shared_ptr<Edge> e) {
     // TODO: implement
     return nullptr;
+}
+
+ostream& operator<<(ostream& out, const Graph& obj) {
+    out << "Vertices by name: ";
+    set<shared_ptr<Vertex>>::iterator iter;
+    for (iter = obj.vertices->begin(); iter != obj.vertices->end(); ++iter) {
+        out << *((*iter).get()) << ", ";
+    }
+    out << "\n";
+    out << "Edges by name: ";
+    set<shared_ptr<Edge>>::iterator it;
+    for (it = obj.edges->begin(); it != obj.edges->end(); ++it) {
+        out << *((*it).get()) << ", ";
+    }
+    out << "\n";
+    return out;
 }

--- a/src/graph/Graph.h
+++ b/src/graph/Graph.h
@@ -22,7 +22,7 @@ class Graph {
         bool separate(shared_ptr<Vertex>, shared_ptr<Vertex>);
         pair<Graph*, Graph*>* splitTree(shared_ptr<Edge> e);
         Graph& operator=(const Graph& rhs);
-        // TODO: operator overload for ostream
+        friend ostream& operator<<(ostream&, const Graph&);
 };
 
 #endif          // GRAPH_H__

--- a/src/graph/Vertex.cpp
+++ b/src/graph/Vertex.cpp
@@ -34,3 +34,8 @@ bool operator==(const Vertex& lhs, const Vertex& rhs) {
 bool operator<(const Vertex& lhs, const Vertex& rhs) {
     return lhs.name < rhs.name;
 }
+
+ostream& operator<<(ostream& o, const Vertex& obj) {
+    o << obj.name;
+    return o;
+}

--- a/src/graph/Vertex.h
+++ b/src/graph/Vertex.h
@@ -18,6 +18,7 @@ class Vertex {
         string getLabel();
         friend bool operator==(const Vertex&, const Vertex&);
         friend bool operator<(const Vertex&, const Vertex&);
+        friend ostream& operator<<(ostream&, const Vertex&);
 };
 
 #endif          // VERTEX_H__

--- a/test/graph/test_graph.cpp
+++ b/test/graph/test_graph.cpp
@@ -33,6 +33,7 @@ bool createNonEmptyGraphFromFile() {
 }
 
 bool createNonEmptyGraphFromBoutiqueVertices() {
+    cout << "Testing graph construction using join()/separate()...\n";
     Graph g;
     shared_ptr<Vertex> v1 = make_shared<Vertex>("a");
     shared_ptr<Vertex> v2 = make_shared<Vertex>("b");
@@ -49,22 +50,32 @@ bool createNonEmptyGraphFromBoutiqueVertices() {
     assert(g.separate(v2, v3));
     cout << "Sep v2 and v3 (b, c) (should fail)..." << endl;
     assert(!g.separate(v2, v3));
+    cout << "Final graph: \n" << g << endl;
+    cout << endl;
     return true;
 }
 
 bool testCopyAssignment() {
+    cout << "Testing copy assignment...\n";
     Graph g;
     assert(g.import("graph_schemas/cycleThree.txt"));
     Graph h;
     h = g;
     assert(&g != &h);
+    cout << "Graph g: \n" << g;
+    cout << "Graph h: \n" << h;
+    cout << endl;
     return true;
 }
 
 bool testCopyConstructor() {
+    cout << "Testing copy constructor...\n";
     Graph g;
     assert(g.import("graph_schemas/cycleThree.txt"));
     Graph h(g);
     assert(&g != &h);
+    cout << "Graph g: \n" << g;
+    cout << "Graph h: \n" << h;
+    cout << endl;
     return true;
 }


### PR DESCRIPTION
Closes #14

Useful for debugging & testing, and used to debug `splitTree(Edge)` function (WIP, see #12)